### PR TITLE
fix [schema path translator]: capitalize only first letter

### DIFF
--- a/lib/error_normalizer/schema_path_translator.rb
+++ b/lib/error_normalizer/schema_path_translator.rb
@@ -42,7 +42,7 @@ class ErrorNormalizer
         translated_tokens << translate_token(token, i, tokens)
       end
 
-      translated_tokens.join(' ').capitalize
+      upcase_sentence(translated_tokens.join(' '))
     end
 
     private
@@ -68,6 +68,10 @@ class ErrorNormalizer
         lookup << "#{token}.@"
         lookup << token
       end
+    end
+
+    def upcase_sentence(string)
+      string.length > 0 ? string[0].upcase.concat(string[1..-1]) : ""
     end
   end
 end

--- a/lib/error_normalizer/version.rb
+++ b/lib/error_normalizer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ErrorNormalizer
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end


### PR DESCRIPTION
Capitalize only first letter in order to save specific capitalized characters in translations